### PR TITLE
Js safety

### DIFF
--- a/adfice-webserver.js
+++ b/adfice-webserver.js
@@ -23,7 +23,11 @@ var iss = "";
 
 function log_debug(server, msg) {
     if (DEBUG) {
-        server.logger.log(msg);
+        if (!server || !server.logger) {
+            console.log(msg);
+        } else {
+            server.logger.log(msg);
+        }
     }
 }
 

--- a/static/message.js
+++ b/static/message.js
@@ -817,7 +817,9 @@ function ws_on_close(event) {
 
 function ws_on_error(err) {
     message_globals.logger.error('Socket error: ', err.message);
-    message_globals.ws.close();
+    if (message_globals.ws) {
+        message_globals.ws.close();
+    }
 };
 
 function connect_web_socket() {

--- a/static/message.js
+++ b/static/message.js
@@ -39,7 +39,9 @@ function send_message(message_type, apply) {
     } catch (err) {
         message_globals.logger.log(err, 'could not send:', msg_str);
         ++message_globals.weirdness;
-        message_globals.ws = null;
+        if (message_globals.ws) {
+            message_globals.ws.close();
+        }
     }
 }
 


### PR DESCRIPTION
I saw what looked to be odd behaviour when testing locally, and uncovered some (long-standing) safety issues that arise in debugging ( 211a673 ), or with faulty network ( 9977fce , 47a21cf ).